### PR TITLE
Add BPMN Constructor MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# GhatTest
-For testing Codex
+# BPMN Constructor
+
+Minimal desktop BPMN constructor built with Electron and React. It generates BPMN diagrams from text using OpenAI Codex.
+
+## Installation
+
+```bash
+npm install
+```
+
+## Development
+
+Run the app in development mode:
+
+```bash
+npm start
+```
+
+The React renderer is served on port `3000` and Electron loads it automatically.
+
+## Build
+
+Create installers for your OS:
+
+```bash
+npm run build
+```
+
+## Configuration
+
+Set the `OPENAI_API_KEY` environment variable before launching the application so that the Codex API can be used.

--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,27 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+require('./src/main');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'src', 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  const startUrl = process.env.NODE_ENV === 'development'
+    ? 'http://localhost:3000'
+    : `file://${path.join(__dirname, 'dist', 'index.html')}`;
+  win.loadURL(startUrl);
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "bpmn-constructor",
+  "version": "0.1.0",
+  "description": "MVP BPMN constructor",
+  "main": "electron.js",
+  "scripts": {
+    "postinstall": "electron-builder install-app-deps",
+    "start": "concurrently \"npm:serve-react\" \"npm:serve-electron\"",
+    "serve-react": "cd src/renderer && npm run dev",
+    "serve-electron": "wait-on tcp:3000 && electron .",
+    "build": "electron-builder"
+  },
+  "dependencies": {
+    "bpmn-js": "^11.5.0",
+    "concurrently": "^8.2.0",
+    "electron": "^28.1.0",
+    "openai": "^4.24.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "electron-builder": "^24.14.1",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "wait-on": "^7.0.1"
+  },
+  "build": {
+    "appId": "com.example.bpmnconstructor",
+    "productName": "BPMNConstructor",
+    "directories": {
+      "buildResources": "public"
+    },
+    "files": [
+      "dist/**",
+      "electron.js",
+      "src/main/**",
+      "src/prompts/**",
+      "src/preload.js"
+    ]
+  }
+}

--- a/public/icon.png
+++ b/public/icon.png
@@ -1,0 +1,1 @@
+placeholder

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,0 +1,27 @@
+const { ipcMain } = require('electron');
+const { Configuration, OpenAIApi } = require('openai');
+const path = require('path');
+const examples = require('../prompts/bpmn');
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+ipcMain.handle('generate', async (_event, description) => {
+  const prompt = examples
+    .map(e => `Text: ${e.text}\nXML:\n${e.xml}`)
+    .join('\n\n');
+
+  const fullPrompt = `${prompt}\n\nText: ${description}\nXML:`;
+
+  try {
+    const res = await openai.createCompletion({
+      model: 'code-davinci-002',
+      prompt: fullPrompt,
+      max_tokens: 500,
+      temperature: 0
+    });
+    return res.data.choices[0].text.trim();
+  } catch (err) {
+    return `<error>${err.message}</error>`;
+  }
+});

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  generate(description) {
+    return ipcRenderer.invoke('generate', description);
+  }
+});

--- a/src/prompts/bpmn.js
+++ b/src/prompts/bpmn.js
@@ -1,0 +1,41 @@
+module.exports = [
+  {
+    text: 'Start to end',
+    xml: `<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <process id="example1" isExecutable="false">
+    <startEvent id="start" />
+    <endEvent id="end" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+  </process>
+</definitions>`
+  },
+  {
+    text: 'Task between start and end',
+    xml: `<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <process id="example2" isExecutable="false">
+    <startEvent id="start" />
+    <task id="task" name="Do work" />
+    <endEvent id="end" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="task" />
+    <sequenceFlow id="f2" sourceRef="task" targetRef="end" />
+  </process>
+</definitions>`
+  },
+  {
+    text: 'Gateway with two tasks',
+    xml: `<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <process id="example3" isExecutable="false">
+    <startEvent id="start" />
+    <exclusiveGateway id="gate" />
+    <task id="task1" name="Option A" />
+    <task id="task2" name="Option B" />
+    <endEvent id="end" />
+    <sequenceFlow id="f1" sourceRef="start" targetRef="gate" />
+    <sequenceFlow id="f2" sourceRef="gate" targetRef="task1" />
+    <sequenceFlow id="f3" sourceRef="gate" targetRef="task2" />
+    <sequenceFlow id="f4" sourceRef="task1" targetRef="end" />
+    <sequenceFlow id="f5" sourceRef="task2" targetRef="end" />
+  </process>
+</definitions>`
+  }
+];

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -1,0 +1,38 @@
+import React, { useState, useRef } from 'react';
+import BpmnJS from 'bpmn-js/lib/Modeler';
+
+function App() {
+  const [description, setDescription] = useState('');
+  const containerRef = useRef(null);
+  const modelerRef = useRef(null);
+
+  const handleGenerate = async () => {
+    const xml = await window.api.generate(description);
+    if (!modelerRef.current) {
+      modelerRef.current = new BpmnJS({ container: containerRef.current });
+    }
+    try {
+      await modelerRef.current.importXML(xml);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <textarea
+        rows={4}
+        style={{ width: '100%' }}
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+      />
+      <button onClick={handleGenerate}>Generate</button>
+      <div
+        ref={containerRef}
+        style={{ height: 500, border: '1px solid #ccc', marginTop: 10 }}
+      ></div>
+    </div>
+  );
+}
+
+export default App;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>BPMN Constructor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/renderer/index.jsx"></script>
+  </body>
+</html>

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "renderer",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  }
+}

--- a/src/renderer/vite.config.js
+++ b/src/renderer/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [react()],
+  build: {
+    outDir: path.resolve(__dirname, '../../dist'),
+    emptyOutDir: true
+  },
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- set up Electron + React project skeleton
- implement OpenAI call in Electron main process
- add React renderer using bpmn-js
- create example prompts for BPMN generation
- document install and build steps

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `npm start` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760f17cb64832aa63272f4a6635d01