### PR TITLE
Style App with external CSS

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -1,0 +1,17 @@
+.app-container {
+  padding: 20px;
+}
+
+.description-input {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.generate-button {
+  margin-bottom: 10px;
+}
+
+.viewer-container {
+  height: 500px;
+  border: 1px solid #ccc;
+}

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import BpmnJS from 'bpmn-js/lib/Modeler';
+import './App.css';
 
 function App() {
   const [description, setDescription] = useState('');
@@ -24,18 +25,18 @@ function App() {
   };
 
   return (
-    <div style={{ padding: 20 }}>
+    <div className="app-container">
+      <h1>BPMN Constructor</h1>
       <textarea
         rows={4}
-        style={{ width: '100%' }}
+        className="description-input"
         value={description}
         onChange={e => setDescription(e.target.value)}
       />
-      <button onClick={handleGenerate}>Generate</button>
-      <div
-        ref={containerRef}
-        style={{ height: 500, border: '1px solid #ccc', marginTop: 10 }}
-      ></div>
+      <button className="generate-button" onClick={handleGenerate}>
+        Generate
+      </button>
+      <div ref={containerRef} className="viewer-container"></div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add new stylesheet with basic layout styles
- import CSS into `App.jsx`
- replace inline styles with CSS classes and add a header element

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68762f305b40832abd58c31495eb8a2d