### PR TITLE
Improve generation UI and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ It uses **React** for the client UI and a small **Express** server to talk to th
    ```bash
    export OPENAI_API_KEY=your_key_here
    ```
-   On Windows PowerShell use:
-   ```powershell
-   $env:OPENAI_API_KEY="your_key_here"
+   On Windows command prompt use:
+   ```cmd
+   set OPENAI_API_KEY=your_key_here
    ```
 5. Start the application in development mode:
    ```bash

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -11,6 +11,15 @@
   margin-bottom: 10px;
 }
 
+.generate-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status-message {
+  margin-bottom: 10px;
+}
+
 .viewer-container {
   height: 500px;
   border: 1px solid #ccc;

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -4,23 +4,31 @@ import './App.css';
 
 function App() {
   const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState('');
   const containerRef = useRef(null);
   const modelerRef = useRef(null);
 
   const handleGenerate = async () => {
-    const response = await fetch('http://localhost:3001/api/generate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ description })
-    });
-    const xml = await response.text();
-    if (!modelerRef.current) {
-      modelerRef.current = new BpmnJS({ container: containerRef.current });
-    }
+    setLoading(true);
+    setStatus('Generating...');
     try {
+      const response = await fetch('http://localhost:3001/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description })
+      });
+      const xml = await response.text();
+      if (!modelerRef.current) {
+        modelerRef.current = new BpmnJS({ container: containerRef.current });
+      }
       await modelerRef.current.importXML(xml);
+      setStatus('');
     } catch (err) {
       console.error(err);
+      setStatus('Failed to generate diagram');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -33,9 +41,14 @@ function App() {
         value={description}
         onChange={e => setDescription(e.target.value)}
       />
-      <button className="generate-button" onClick={handleGenerate}>
+      <button
+        className="generate-button"
+        onClick={handleGenerate}
+        disabled={loading}
+      >
         Generate
       </button>
+      {status && <p className="status-message">{status}</p>}
       <div ref={containerRef} className="viewer-container"></div>
     </div>
   );


### PR DESCRIPTION
## Summary
- disable the Generate button during API requests
- show a small status message for feedback
- add basic styles for the disabled button and status text
- fix Windows environment variable command in the README

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687631f5df14832a936f90384a870dba