### PR TITLE
Use OpenAI client v4 API

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const cors = require('cors');
-const { Configuration, OpenAIApi } = require('openai');
+const OpenAI = require('openai');
 const examples = require('./src/prompts/bpmn');
 
 const app = express();
@@ -16,8 +16,9 @@ app.use((req, res, next) => {
   next();
 });
 
-const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
-const openai = new OpenAIApi(configuration);
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
 
 app.post('/api/generate', async (req, res) => {
   const { description } = req.body;
@@ -28,13 +29,13 @@ app.post('/api/generate', async (req, res) => {
   const fullPrompt = `${prompt}\n\nText: ${description}\nXML:`;
 
   try {
-    const result = await openai.createCompletion({
+    const result = await openai.completions.create({
       model: 'code-davinci-002',
       prompt: fullPrompt,
       max_tokens: 500,
       temperature: 0,
     });
-    res.send(result.data.choices[0].text.trim());
+    res.send(result.choices[0].text.trim());
   } catch (err) {
     console.error('OpenAI API error:', err);
     res.status(500).send(`<error>${err.message}</error>`);


### PR DESCRIPTION
## Summary
- update `server.js` to instantiate `OpenAI` client with v4 API
- adjust completion call to `openai.completions.create`

## Testing
- `npm test` *(fails: Missing script)*
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68763aa6bee4832aa14d83c553fab6a8