### PR TITLE
Handle fetch errors before importing XML

### DIFF
--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -19,6 +19,12 @@ function App() {
         body: JSON.stringify({ description })
       });
       const xml = await response.text();
+
+      if (!response.ok) {
+        setStatus(`Failed to generate diagram: ${xml}`);
+        return;
+      }
+
       if (!modelerRef.current) {
         modelerRef.current = new BpmnJS({ container: containerRef.current });
       }


### PR DESCRIPTION
## Summary
- handle failed responses when requesting a BPMN XML

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68763d274240832a8aa4560e98fb33e5