### PR TITLE
Check for OPENAI_API_KEY before server start

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,13 @@ const cors = require('cors');
 const OpenAI = require('openai');
 const examples = require('./src/prompts/bpmn');
 
+if (!process.env.OPENAI_API_KEY) {
+  console.error(
+    'Error: OPENAI_API_KEY environment variable is not set. Please provide your OpenAI API key.'
+  );
+  process.exit(1);
+}
+
 const app = express();
 const port = process.env.PORT || 3001;
 


### PR DESCRIPTION
## Summary
- verify OPENAI_API_KEY at startup and exit if not set

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68763fd50940832ab93c6b80e420dcab