### PR TITLE
Fix public assets path

### DIFF
--- a/src/renderer/vite.config.js
+++ b/src/renderer/vite.config.js
@@ -4,6 +4,8 @@ import path from 'path';
 
 export default defineConfig({
   root: __dirname,
+  // Serve static assets from the repository root "public" directory
+  publicDir: path.resolve(__dirname, '../../public'),
   plugins: [react()],
   build: {
     outDir: path.resolve(__dirname, '../../dist'),


### PR DESCRIPTION
## Summary
- point Vite's `publicDir` at the repo root so static assets load correctly

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build-react` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876412bcb4c832a8c5c7e72ae67b53a