### PR TITLE
Fix deprecated model usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,8 @@ app.post('/api/generate', async (req, res) => {
 
   try {
     const result = await openai.completions.create({
-      model: 'code-davinci-002',
+      // code-davinci-002 has been deprecated in favor of gpt-3.5-turbo-instruct
+      model: 'gpt-3.5-turbo-instruct',
       prompt: fullPrompt,
       max_tokens: 500,
       temperature: 0,


### PR DESCRIPTION
## Summary
- update OpenAI model from `code-davinci-002` to `gpt-3.5-turbo-instruct`

## Testing
- `OPENAI_API_KEY=dummy node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_687642da4964832a9b29b4669dd4aebd