### PR TITLE
refactor renderer entry

### DIFF
--- a/src/renderer/src/main.jsx
+++ b/src/renderer/src/main.jsx
@@ -1,14 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import App from '../App';
 
-function App() {
-  return <h1>React OK</h1>;
-}
-
-export default App;
-
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+ReactDOM.createRoot(document.getElementById('root')).render(<React.StrictMode><App /></React.StrictMode>);


### PR DESCRIPTION
## Summary
- streamline `src/renderer/src/main.jsx` to import the app component
- remove old placeholder `App` function
- call `ReactDOM.createRoot` in a single line

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6876603794b8832a8f8a173d194c2445