### PR TITLE
Add token count API and client integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,6 +31,12 @@ app.use(cors());
 app.use(express.json());
 app.use(express.static('dist'));
 
+app.post('/api/token-count', (req, res) => {
+  const { text } = req.body;
+  const count = encode(text).length;
+  res.json({ count });
+});
+
 app.get('/api/config', (req, res) => {
   res.json({
     systemPrompt,


### PR DESCRIPTION
## Summary
- add `/api/token-count` endpoint on the server
- remove `gpt-3-encoder` from the React app
- fetch the token count from the backend and update the token limit logic

## Testing
- `npm start` *(fails: concurrently not found because dependencies can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_687663dcf354832a81c9b615cf52f4e5