### PR TITLE
Add model selector and save options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ node server.js
 
 This creates a `dist` folder and serves it on `http://localhost:3001`.
 
+## Model Selection and Saving
+
+When the app loads it fetches the list of available OpenAI models from the server.
+You can choose the desired model in the drop-down above the prompt field. After a
+diagram is generated the interface displays the approximate price of the request
+and provides buttons to save the result as XML or PNG.
+
 ## Updating Dependencies
 
 All dependency versions are listed in `package.json`. If newer versions are

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -67,3 +67,15 @@ h1 {
   border: 1px solid #ccc;
   background-color: white;
 }
+
+.model-select-wrapper {
+  margin-bottom: 10px;
+}
+
+.model-select-wrapper select {
+  margin-left: 5px;
+}
+
+.cost-display {
+  margin-left: 10px;
+}

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -12,6 +12,10 @@ function App() {
   const [isOverLimit, setIsOverLimit] = useState(false);
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState('');
+  const [tokenCount, setTokenCount] = useState(0);
+  const [availableModels, setAvailableModels] = useState([]);
+  const [model, setModel] = useState('gpt-3.5-turbo-instruct');
+  const [requestCost, setRequestCost] = useState(0);
   const containerRef = useRef(null);
   const modelerRef = useRef(null);
 
@@ -24,6 +28,10 @@ function App() {
         setMaxPromptTokens(cfg.maxPromptTokens || 0);
         if (cfg.promptLimitMessage) {
           setLimitMessage(cfg.promptLimitMessage);
+        }
+        if (Array.isArray(cfg.availableModels)) {
+          setAvailableModels(cfg.availableModels);
+          setModel(cfg.availableModels[0] || model);
         }
         setErrorMessage('');
       } catch (err) {
@@ -43,6 +51,7 @@ function App() {
         });
         const data = await res.json();
         const count = data.count || 0;
+        setTokenCount(count);
         if (maxPromptTokens && count > maxPromptTokens) {
           setIsOverLimit(true);
           setErrorMessage(limitMessage);
@@ -64,7 +73,7 @@ function App() {
       const response = await fetch('/api/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ description, globalPrompt })
+        body: JSON.stringify({ description, globalPrompt, model })
       });
       const text = await response.text();
 
@@ -73,15 +82,18 @@ function App() {
         return;
       }
 
+      let xml = text;
+      let cost = 0;
       if (text.startsWith('{')) {
         const data = JSON.parse(text);
         if (data.error) {
           setStatus(`Failed to generate diagram: ${data.error}`);
           return;
         }
+        xml = data.xml;
+        cost = data.cost || 0;
+        setRequestCost(cost);
       }
-
-      const xml = text;
 
       if (!modelerRef.current) {
         modelerRef.current = new BpmnJS({ container: containerRef.current });
@@ -96,9 +108,62 @@ function App() {
     }
   };
 
+  const handleSaveXml = async () => {
+    if (!modelerRef.current) return;
+    try {
+      const { xml } = await modelerRef.current.saveXML({ format: true });
+      const blob = new Blob([xml], { type: 'application/xml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'diagram.bpmn';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to save XML', err);
+    }
+  };
+
+  const handleSavePng = async () => {
+    if (!modelerRef.current) return;
+    try {
+      const { svg } = await modelerRef.current.saveSVG();
+      const canvas = document.createElement('canvas');
+      const img = new Image();
+      img.onload = () => {
+        canvas.width = img.width;
+        canvas.height = img.height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        canvas.toBlob(blob => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'diagram.png';
+          a.click();
+          URL.revokeObjectURL(url);
+        });
+      };
+      img.src = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svg)));
+    } catch (err) {
+      console.error('Failed to save PNG', err);
+    }
+  };
+
   return (
     <div className="app-container">
       <h1>BPMN Constructor</h1>
+      <div className="model-select-wrapper">
+        <label>
+          Model:
+          <select value={model} onChange={e => setModel(e.target.value)}>
+            {availableModels.map(m => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </label>
+        <span className="cost-display">{`Cost: $${requestCost.toFixed(4)}`}</span>
+      </div>
       <textarea
         rows={4}
         className={`prompt-input${isOverLimit ? ' over-limit' : ''}`}
@@ -113,6 +178,7 @@ function App() {
         onChange={e => setDescription(e.target.value)}
         placeholder="Your description"
       />
+      <p>Tokens: {tokenCount}{maxPromptTokens ? ` / ${maxPromptTokens}` : ''}</p>
       <button
         className="generate-button"
         onClick={handleGenerate}
@@ -120,6 +186,12 @@ function App() {
       >
         Generate
       </button>
+      {modelerRef.current && (
+        <>
+          <button className="generate-button" onClick={handleSaveXml}>Save XML</button>
+          <button className="generate-button" onClick={handleSavePng}>Save PNG</button>
+        </>
+      )}
       {errorMessage && isOverLimit && (
         <p className="status-message">{errorMessage}</p>
       )}


### PR DESCRIPTION
## Summary
- add dropdown to select an OpenAI model and display request cost
- expose available models in `/api/config`
- return pricing info from `/api/generate`
- show token count in UI
- enable saving diagrams as XML or PNG
- document the new behaviour

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766e6ea768832aa6f04897a0eba939